### PR TITLE
Ubuntu compatibility changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,7 @@ class passenger (
 
   case $osfamily {
     'debian': {
-      package { ['libopenssl-ruby', 'libcurl4-openssl-dev']:
+      package { [$passenger::params::libruby, 'libcurl4-openssl-dev']:
         ensure => present,
         before => Exec['compile-passenger'],
       }
@@ -117,7 +117,7 @@ class passenger (
   }
 
   exec {'compile-passenger':
-    path      => [ $gem_binary_path, '/usr/bin', '/bin'],
+    path      => [ $gem_binary_path, '/usr/bin', '/bin', '/usr/local/bin' ],
     command   => 'passenger-install-apache2-module -a',
     logoutput => on_failure,
     creates   => $mod_passenger_location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,13 @@ class passenger::params {
       $gem_path               = '/var/lib/gems/1.8/gems'
       $gem_binary_path        = '/var/lib/gems/1.8/bin'
       $mod_passenger_location = "/var/lib/gems/1.8/gems/passenger-$passenger_version/ext/apache2/mod_passenger.so"
+
+      # Ubuntu does not have libopenssl-ruby - it's packaged in libruby
+      if $lsbdistid == 'Ubuntu' {
+        $libruby              = 'libruby'
+      } else {
+        $libruby              = 'libopenssl-ruby'
+      }
     }
     'redhat': {
       $passenger_package      = 'passenger'


### PR DESCRIPTION
Two changes that I had to make for this module to run on Ubuntu 12.04:
- Change the libruby package
- Add /usr/local/bin to the path of compile-passenger exec.
