### PR TITLE
new parameter passenger_ruby

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@
 #
 #  class { 'passenger':
 #    passenger_version      => '3.0.9',
+#    passenger_ruby         => '/usr/bin/ruby'
 #    gem_path               => '/var/lib/gems/1.8/gems',
 #    gem_binary_path        => '/var/lib/gems/1.8/bin',
 #    mod_passenger_location => '/var/lib/gems/1.8/gems/passenger-3.0.9/ext/apache2/mod_passenger.so',
@@ -40,6 +41,7 @@
 #
 class passenger (
   $passenger_version      = $passenger::params::passenger_version,
+  $passenger_ruby         = $passenger::params::passenger_ruby,
   $gem_path               = $passenger::params::gem_path,
   $gem_binary_path        = $passenger::params::gem_binary_path,
   $mod_passenger_location = $passenger::params::mod_passenger_location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@
 #
 class passenger::params {
   $passenger_version  = '3.0.9'
+  $passenger_ruby     = '/usr/bin/ruby'
   $passenger_provider = 'gem'
 
   case $osfamily {

--- a/templates/passenger-conf.erb
+++ b/templates/passenger-conf.erb
@@ -1,6 +1,6 @@
 LoadModule passenger_module <%= gem_path %>/passenger-<%= passenger_version %>/ext/apache2/mod_passenger.so
 PassengerRoot <%= gem_path %>/passenger-<%= passenger_version %>
-PassengerRuby /usr/bin/ruby
+PassengerRuby <%= passenger_ruby %>
 
 # you probably want to tune these settings
 PassengerHighPerformance on


### PR DESCRIPTION
This pull request extends the ability to control the PassengerRuby directive using the new class parameter passenger_ruby. This more easily allows those using this module to use custom ruby installations that may be located somewhere other than /usr/bin/ruby (though /usr/bin/ruby is kept as the sane default if the new parameter is not utilized).
