### PR TITLE
Debian Squeeze uses libruby instead of libopenssl-ruby

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,8 @@ class passenger::params {
       # Ubuntu does not have libopenssl-ruby - it's packaged in libruby
       if $::lsbdistid == 'Ubuntu' {
         $libruby              = 'libruby'
+      } elsif $::lsbdistcodename == 'squeeze' {
+        $libruby              = 'libruby'
       } else {
         $libruby              = 'libopenssl-ruby'
       }


### PR DESCRIPTION
Debian Squeeze does not have libopenssl-ruby - it's packaged in libruby, adding another if for that package
