### PR TITLE
Updated content to conform to README best practices template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
-# Passenger Module
+passenger
+=========
 
-This module is used for configuring Passenger (http://www.modrails.com)
+Overview
+--------
 
-# Quick Start
+The Passenger module allows easy configuration and management of Phusion Passenger.      
 
-This module was developed and tested against RHEL and Debian based systems (Centos, Fedora, Redhat, Debian, Ubuntu). This module may require you to specify default parameter values to accommodate other distributions. 
+Module Description
+-------------------
 
-To declare the class in your node declaration, you can do the following:
+The Passenger module lets you run Rails or Rack inside Apache with ease. Utilizing [Passenger](http://www.modrails.com), an application server for Ruby (Rack) and Python (WSGI) apps, the Passenger module enables quick configuration of Passenger for Apache. 
+
+Setup
+-----
+
+**What Passenger affects:**
+
+* Apache
+* installs packages on chosen nodes 
+* package/service/configuration files for Passenger
+	
+### Beginning with Passenger	
+
+Install and begin managing Passenger on a node by declaring the class in your node definition:
 
     node default {
       class {'passenger': }
     }
 
-The Passenger module will attempt to apply sane default values to all its parameters, but you can manually specify them using the below syntax:
+This will establish Passenger on your node with sane default values. However, you can manually set the parameter values:
 
     node default {
       class {'passenger':
@@ -24,7 +40,62 @@ The Passenger module will attempt to apply sane default values to all its parame
         mod_passenger_location => '/var/lib/gems/1.8/gems/passenger-2.2.11/ext/apache2/mod_passenger.so',
       }
     }
+ 
+Usage
+------
 
-# Dependencies
+The `passenger` class has a set of configurable parameters that allow you to control aspects of Passenger's installation. 
 
-This module requires the Puppetlabs gcc and apache module for its functionality.  You may retrieve those modules from http://forge.puppetlabs.com
+**Parameters within `passenger`**
+
+####`passenger_version`
+
+The Version of Passenger to be installed
+
+####`gem_path`
+
+The path to rubygems on your system
+
+####`gem_binary_path`
+
+Path to Rubygems binaries on your system
+
+####`mod_passenger_location`
+
+Path to Passenger's mod_passenger.so file
+
+####`passenger_provider`
+
+The package provider to use for the system
+
+####`passenger_package`
+
+The name of the Passenger package
+
+Implementation
+---------------
+
+This module operates by compiling Ruby gems on the system being managed. 
+
+Limitations
+------------
+
+This module was developed and tested against RHEL and Debian based systems (Centos, Fedora, Redhat, Debian, Ubuntu). This module may require you to specify default parameter values to accommodate other distributions.
+
+Development
+------------
+
+Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
+
+We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+
+You can read the complete module contribution guide [on the Puppet Labs wiki.](http://projects.puppetlabs.com/projects/module-site/wiki/Module_contributing)
+
+Release Notes
+--------------
+
+**0.0.4 Release**
+
+* Remove puppetlabs-gcc dependency
+* Add package dependencies for Passenger 3.0
+* Re-order resources (removing chaining syntax)


### PR DESCRIPTION
Before alterations, this content was the module author-determined
description of and instructions for use of the module.

As part of a joint Forge/Docs team effort to standardize formatting and
encourage quality module documentation, a best practices README
template was created via internal and external user testing. That
template was then applied to this module.

I pulled in content from the original README on GitHub. Standard
headings were added (Overview, Module Description, Setup, Usage,
Implementation, etc.) to organize content, existent content was moved
under its appropriate heading and edited for tone/flow/clarity, links
to outside documentation were updated, and basic formatting was done to
adhere to template standards.
