### PR TITLE
Fix template deprecation warnings generated in puppet 3

### DIFF
--- a/templates/passenger-conf.erb
+++ b/templates/passenger-conf.erb
@@ -1,6 +1,6 @@
-LoadModule passenger_module <%= gem_path %>/passenger-<%= passenger_version %>/ext/apache2/mod_passenger.so
-PassengerRoot <%= gem_path %>/passenger-<%= passenger_version %>
-PassengerRuby <%= passenger_ruby %>
+LoadModule passenger_module <%= @gem_path %>/passenger-<%= @passenger_version %>/ext/apache2/mod_passenger.so
+PassengerRoot <%= @gem_path %>/passenger-<%= @passenger_version %>
+PassengerRuby <%= @passenger_ruby %>
 
 # you probably want to tune these settings
 PassengerHighPerformance on

--- a/templates/passenger-enabled.erb
+++ b/templates/passenger-enabled.erb
@@ -1,5 +1,5 @@
 <IfModule mod_passenger.c>
-	PassengerRoot <%= gem_path %>/passenger-<%= passenger_version %>
+	PassengerRoot <%= @gem_path %>/passenger-<%= @passenger_version %>
 	PassengerRuby /usr/bin/ruby
 
 	# you probably want to tune these settings

--- a/templates/passenger-load.erb
+++ b/templates/passenger-load.erb
@@ -1,1 +1,1 @@
-LoadModule passenger_module <%= gem_path %>/passenger-<%= passenger_version %>/ext/apache2/mod_passenger.so
+LoadModule passenger_module <%= @gem_path %>/passenger-<%= @passenger_version %>/ext/apache2/mod_passenger.so


### PR DESCRIPTION
In puppet 3 you'll see deprecations warnings like:

```
Warning: Variable access via 'gem_path' is deprecated. Use '@gem_path' instead. template[/.../modules/passenger/templates/passenger-conf.erb]:1
   (at /.../puppet/modules/passenger/templates/passenger-conf.erb:1:in `result')
Warning: Variable access via 'gem_path' is deprecated. Use '@gem_path' instead. template[/.../puppet/modules/passenger/templates/passenger-conf.erb]:2
   (at /.../puppet/modules/passenger/templates/passenger-conf.erb:2:in `result')
Warning: Variable access via 'passenger_ruby' is deprecated. Use '@passenger_ruby' instead. template[/.../puppet/modules/passenger/templates/passenger-conf.erb]:3
   (at /.../puppet/modules/passenger/templates/passenger-conf.erb:3:in `result')
```
