### PR TITLE
Update the apache2 module dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class passenger (
 ) inherits passenger::params {
 
   include apache
-  require apache::mod::dev
+  require apache::dev
 
   case $::osfamily {
     'debian': {


### PR DESCRIPTION
## Update the apache dependency to the version 0.7.0

It avoids this annoying warning:

> Warning: Scope(Class[Apache::Mod::Dev]): apache::mod::dev is deprecated; please use apache::dev
