### PR TITLE
use the @mod_passenger_location variable in the conf file template

### DIFF
--- a/templates/passenger-conf.erb
+++ b/templates/passenger-conf.erb
@@ -1,4 +1,4 @@
-LoadModule passenger_module <%= @gem_path %>/passenger-<%= @passenger_version %>/ext/apache2/mod_passenger.so
+LoadModule passenger_module <%= @mod_passenger_location %>
 PassengerRoot <%= @gem_path %>/passenger-<%= @passenger_version %>
 PassengerRuby <%= @passenger_ruby %>
 


### PR DESCRIPTION
Found that when implementing the class like so

```
class { '::passenger':
  mod_passenger_location => "$passenger_root/buildout/apache2/mod_passenger.so",
}
```

The LoadModule directive of the passenger.conf file ignored this variable in favor of a hard-coded value. This should fix that.
