### PR TITLE
Add support for Passenger 4.x.x

### DIFF
--- a/templates/passenger-conf.erb
+++ b/templates/passenger-conf.erb
@@ -8,4 +8,9 @@ PassengerMaxPoolSize 12
 PassengerPoolIdleTime 1500
 # PassengerMaxRequests 1000
 PassengerStatThrottleRate 120
+
+<% if @passenger_version =~ /^4\.\d+\.\d+/ %>
+PassengerEnabled on
+<% else %>
 RailsAutoDetect On
+<% end %>

--- a/templates/passenger-enabled.erb
+++ b/templates/passenger-enabled.erb
@@ -1,6 +1,6 @@
 <IfModule mod_passenger.c>
 	PassengerRoot <%= @gem_path %>/passenger-<%= @passenger_version %>
-  PassengerRuby <%= @passenger_ruby %>
+	PassengerRuby <%= @passenger_ruby %>
 
 	# you probably want to tune these settings
 	PassengerHighPerformance on
@@ -8,5 +8,11 @@
 	PassengerPoolIdleTime 1500
 	# PassengerMaxRequests 1000
 	PassengerStatThrottleRate 120
+	
+	<% if @passenger_version =~ /^4\.\d+\.\d+/ %>
+	PassengerEnabled on
+	<% else %>
 	RailsAutoDetect On
+	<% end %>
+
 </IfModule>


### PR DESCRIPTION
Use `PassengerEnabled` instead of `RailsAutoDetect` for passenger 4.x.x

Manually tested with:
- Ubuntu LTS 12.04
- Ruby 2.0.0-p247 (installed with ruby-build)
- Passenger 4.0.14

``` puppet
class { 'passenger':
  passenger_version      => '4.0.14',
  passenger_ruby         => '/usr/bin/ruby',
  gem_path               => "/usr/lib/ruby/gems/2.0.0/gems",
  gem_binary_path        => '/usr/bin',
  mod_passenger_location => "/usr/lib/ruby/gems/2.0.0/gems/passenger-4.0.14/buildout/apache2/mod_passenger.so",
  passenger_provider     => 'gem',
  passenger_package      => 'passenger',
}

```
