### PR TITLE
RHEL 5 doesn't have package 'libcurl-devel', should be called 'curl-deve...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,9 +100,18 @@ class passenger (
       }
     }
     'redhat': {
-      package { 'libcurl-devel':
-        ensure => present,
-        before => Exec['compile-passenger'],
+      case $::lsbmajdistrelease {
+        '5': {
+          $curl_package = 'curl-devel'
+        }
+      default: {
+          $curl_package = 'libcurl-devel'
+        }
+      }
+
+      package {  $curl_package:
+         ensure => present,
+         before => Exec['compile-passenger'],
       }
 
       file { '/etc/httpd/conf.d/passenger.conf':


### PR DESCRIPTION
...l'
