### PR TITLE
Adding additional dependencies for redhat derived distro

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class passenger::params {
       }
     }
     'redhat': {
-      $package_dependencies   = [ 'libcurl-devel' ]
+      $package_dependencies   = [ 'libcurl-devel', 'openssl-devel', 'zlib-devel' ]
       $package_name           = 'passenger'
       $passenger_package      = 'passenger'
       $gem_path               = '/usr/lib/ruby/gems/1.8/gems'


### PR DESCRIPTION
Adding openssl-devel and zlib-devel as dependent packages in redhat
based distros.  CentOS in particular was failing to compile passenger
without these packages.
