### PR TITLE
Remove unused dependency on stdlib

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,8 +2,6 @@ fixtures:
   repositories:
     apache:
       repo: 'git://github.com/puppetlabs/puppetlabs-apache.git'
-    stdlib:
-      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
     concat:
       repo: 'git://github.com/puppetlabs/puppetlabs-concat.git'
   symlinks:

--- a/Modulefile
+++ b/Modulefile
@@ -9,4 +9,3 @@ project_page 'https://github.com/puppetlabs/puppetlabs-passenger'
 
 dependency 'puppetlabs/apache', '>= 0.0.3'
 dependency 'puppetlabs/ruby', '>= 0.0.1'
-dependency 'puppetlabs/stdlib'


### PR DESCRIPTION
This patch would remove the dependency on puppetlabs/stdlib, since it is
not actually being utilized.
