### PR TITLE
Use the last version in the 3.0.x releases as the default.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,12 +31,12 @@
 # Usage:
 #
 #  class { 'passenger':
-#    passenger_version      => '3.0.9',
+#    passenger_version      => '3.0.21',
 #    passenger_ruby         => '/usr/bin/ruby'
 #    gem_path               => '/var/lib/gems/1.8/gems',
 #    gem_binary_path        => '/var/lib/gems/1.8/bin',
-#    passenger_root         => '/var/lib/gems/1.8/gems/passenger-3.0.9'
-#    mod_passenger_location => '/var/lib/gems/1.8/gems/passenger-3.0.9/ext/apache2/mod_passenger.so',
+#    passenger_root         => '/var/lib/gems/1.8/gems/passenger-3.0.21'
+#    mod_passenger_location => '/var/lib/gems/1.8/gems/passenger-3.0.21/ext/apache2/mod_passenger.so',
 #    passenger_provider     => 'gem',
 #    passenger_package      => 'passenger',
 #  }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,8 @@
 # Sample Usage:
 #
 class passenger::params {
-  $package_ensure     = '3.0.9'
-  $passenger_version  = '3.0.9'
+  $package_ensure     = '3.0.21'
+  $passenger_version  = '3.0.21'
   $passenger_ruby     = '/usr/bin/ruby'
   $package_provider   = 'gem'
   $passenger_provider = 'gem'


### PR DESCRIPTION
This patch uses v3.0.21 of passenger, the last in the 3.0.x branch as
the default instead of 3.0.9, which was likely just the newest at the
time the module was created.
