### PR TITLE
Fixed timeout when compiling passenger on 'slow' machines

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -5,6 +5,7 @@ class passenger::compile {
     command   => 'passenger-install-apache2-module -a',
     logoutput => on_failure,
     creates   => $passenger::mod_passenger_location,
+    timeout   => 0,
   }
 
 }


### PR DESCRIPTION
I'm trying to compile passenger on a virtual machine and I run into puppet's default timeout of 300 seconds. By setting the timeout to '0' in the compile task, the compilation completes successfully.
