### PR TITLE
RHEL 5 doesn't have package 'libcurl-devel', should be called 'curl-devel'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,11 @@ class passenger::params {
       }
     }
     'redhat': {
-      $package_dependencies   = [ 'libcurl-devel', 'openssl-devel', 'zlib-devel' ]
+      case $::lsbmajdistrelease {
+        '5'     : { $curl_package = 'curl-devel' }
+        default : { $curl_package = 'libcurl-devel' }
+      }
+      $package_dependencies   = [ $curl_package, 'openssl-devel', 'zlib-devel' ]
       $package_name           = 'passenger'
       $passenger_package      = 'passenger'
       $gem_path               = '/usr/lib/ruby/gems/1.8/gems'


### PR DESCRIPTION
re-applied the change