### PR TITLE
add required packages for RedHat OS family

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class passenger::params {
       }
     }
     'redhat': {
-      $package_dependencies   = [ 'libcurl-devel', 'openssl-devel', 'zlib-devel' ]
+      $package_dependencies   = [ 'libcurl-devel', 'openssl-devel', 'zlib-devel', 'ruby-devel', 'gcc-c++' ]
       $package_name           = 'passenger'
       $passenger_package      = 'passenger'
       $gem_path               = '/usr/lib/ruby/gems/1.8/gems'


### PR DESCRIPTION
For RedHat family OS the following packages are needed in additional to the current list:
ruby-devel & gcc-c++

I added those packages to the required package list in the params,pp file