### PR TITLE
inserted builddir variable into mod_passenger_location for each case

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class passenger::params {
       $gem_path               = '/var/lib/gems/1.8/gems'
       $gem_binary_path        = '/var/lib/gems/1.8/bin'
       $passenger_root         = "/var/lib/gems/1.8/gems/passenger-${passenger_version}"
-      $mod_passenger_location = "/var/lib/gems/1.8/gems/passenger-${passenger_version}/ext/apache2/mod_passenger.so"
+      $mod_passenger_location = "/var/lib/gems/1.8/gems/passenger-${passenger_version}/${builddir}/apache2/mod_passenger.so"
 
       # Ubuntu does not have libopenssl-ruby - it's packaged in libruby
       if $::lsbdistid == 'Debian' and $::lsbmajdistrelease <= 5 {
@@ -46,7 +46,7 @@ class passenger::params {
       $gem_path               = '/usr/lib/ruby/gems/1.8/gems'
       $gem_binary_path        = '/usr/lib/ruby/gems/1.8/gems/bin'
       $passenger_root         = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}"
-      $mod_passenger_location = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}/ext/apache2/mod_passenger.so"
+      $mod_passenger_location = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}/${builddir}/apache2/mod_passenger.so"
     }
     'darwin':{
       $package_name           = 'passenger'
@@ -54,7 +54,7 @@ class passenger::params {
       $gem_path               = '/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin'
       $gem_binary_path        = '/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin'
       $passenger_root         = "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/passenger-${passenger_version}"
-      $mod_passenger_location = "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/passenger-${passenger_version}/ext/apache2/mod_passenger.so"
+      $mod_passenger_location = "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/passenger-${passenger_version}/${builddir}/apache2/mod_passenger.so"
     }
     default: {
       fail("Operating system ${::operatingsystem} is not supported with the Passenger module")


### PR DESCRIPTION
Installed passenger 4.0.42 and found that the $builddir var wasn't being used. Inserted it into each case.