### PR TITLE
fix issue where packages may have duplicate ensure

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,9 +7,9 @@ class passenger::install {
   }
 
   if $passenger::package_dependencies {
-    package { $passenger::package_dependencies:
-      ensure => present,
-    }
+    ensure_packages($passenger::package_dependencies,
+      { 'ensure' => 'present' }
+    )
   }
 
 }


### PR DESCRIPTION
In some larger puppet environments other modules may also declare similar packages to the passenger module. One example is "openssl-devel".

Use stdlib "ensure_packages" to help with duplicate pkg ensure. Since the stdlib is already a dependency I did not see any issues with using the function.

see: https://forge.puppetlabs.com/puppetlabs/stdlib#ensure_packages