### PR TITLE
updates for redhat 7 and to allow for more control over what module does with passenger.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 #
 class passenger::config (
   $passenger_conf_template = $passenger::params::passenger_conf_template,
-  $passenger_load_template = $passenger::params::passenger_load_template,  
+  $passenger_load_template = $passenger::params::passenger_load_template,
 ) inherits passenger::params {
 
   case $::osfamily {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,14 @@
 #
-class passenger::config {
+class passenger::config (
+  $passenger_conf_template = $passenger::params::passenger_conf_template,
+  $passenger_load_template = $passenger::params::passenger_load_template,  
+) inherits passenger::params {
 
   case $::osfamily {
     'debian': {
       file { '/etc/apache2/mods-available/passenger.load':
         ensure  => present,
-        content => template('passenger/passenger-load.erb'),
+        content => template($passenger_load_template),
         owner   => '0',
         group   => '0',
         mode    => '0644',
@@ -14,7 +17,7 @@ class passenger::config {
 
       file { '/etc/apache2/mods-available/passenger.conf':
         ensure  => present,
-        content => template('passenger/passenger-enabled.erb'),
+        content => template($passenger_conf_template),
         owner   => '0',
         group   => '0',
         mode    => '0644',
@@ -45,7 +48,7 @@ class passenger::config {
 
       file { '/etc/httpd/conf.d/passenger.conf':
         ensure  => present,
-        content => template('passenger/passenger-conf.erb'),
+        content => template($passenger_conf_template),
         owner   => '0',
         group   => '0',
         mode    => '0644',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,14 +1,11 @@
 #
-class passenger::config (
-  $passenger_conf_template = $passenger::params::passenger_conf_template,
-  $passenger_load_template = $passenger::params::passenger_load_template,
-) inherits passenger::params {
+class passenger::config {
 
   case $::osfamily {
     'debian': {
       file { '/etc/apache2/mods-available/passenger.load':
         ensure  => present,
-        content => template($passenger_load_template),
+        content => template($passenger::passenger_load_template),
         owner   => '0',
         group   => '0',
         mode    => '0644',
@@ -17,7 +14,7 @@ class passenger::config (
 
       file { '/etc/apache2/mods-available/passenger.conf':
         ensure  => present,
-        content => template($passenger_conf_template),
+        content => template($passenger::passenger_conf_template),
         owner   => '0',
         group   => '0',
         mode    => '0644',
@@ -48,7 +45,7 @@ class passenger::config (
 
       file { '/etc/httpd/conf.d/passenger.conf':
         ensure  => present,
-        content => template($passenger_conf_template),
+        content => template($passenger::passenger_conf_template),
         owner   => '0',
         group   => '0',
         mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,24 +58,35 @@ class passenger (
   $passenger_root         = $passenger::params::passenger_root,
   $passenger_ruby         = $passenger::params::passenger_ruby,
   $passenger_version      = $passenger::params::passenger_version,
+  $install_config         = $passenger::params::install_config,
 ) inherits passenger::params {
 
   include '::apache'
   include '::apache::dev'
 
   include '::passenger::install'
-  include '::passenger::config'
+  if $install_config {
+    include '::passenger::config'
+  }
   include '::passenger::compile'
 
   anchor { 'passenger::begin': }
   anchor { 'passenger::end': }
 
   #projects.puppetlabs.com - bug - #8040: Anchoring pattern
-  Anchor['passenger::begin'] ->
-  Class['apache::dev'] ->
-  Class['passenger::install'] ->
-  Class['passenger::compile'] ->
-  Class['passenger::config'] ->
-  Anchor['passenger::end']
-
+  if $install_config {
+    Anchor['passenger::begin'] ->
+    Class['apache::dev'] ->
+    Class['passenger::install'] ->
+    Class['passenger::compile'] ->
+    Class['passenger::config'] ->
+    Anchor['passenger::end']
+  } else {
+    # anchoring pattern without config
+    Anchor['passenger::begin'] ->
+    Class['apache::dev'] ->
+    Class['passenger::install'] ->
+    Class['passenger::compile'] ->
+    Anchor['passenger::end']
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,18 +47,20 @@
 #   - apache::dev
 #
 class passenger (
-  $gem_binary_path        = $passenger::params::gem_binary_path,
-  $gem_path               = $passenger::params::gem_path,
-  $mod_passenger_location = $passenger::params::mod_passenger_location,
-  $package_name           = $passenger::params::package_name,
-  $package_ensure         = $passenger::params::package_ensure,
-  $package_provider       = $passenger::params::package_provider,
-  $passenger_package      = $passenger::params::passenger_package,
-  $passenger_provider     = $passenger::params::passenger_provider,
-  $passenger_root         = $passenger::params::passenger_root,
-  $passenger_ruby         = $passenger::params::passenger_ruby,
-  $passenger_version      = $passenger::params::passenger_version,
-  $install_config         = $passenger::params::install_config,
+  $gem_binary_path         = $passenger::params::gem_binary_path,
+  $gem_path                = $passenger::params::gem_path,
+  $mod_passenger_location  = $passenger::params::mod_passenger_location,
+  $package_name            = $passenger::params::package_name,
+  $package_ensure          = $passenger::params::package_ensure,
+  $package_provider        = $passenger::params::package_provider,
+  $passenger_package       = $passenger::params::passenger_package,
+  $passenger_provider      = $passenger::params::passenger_provider,
+  $passenger_root          = $passenger::params::passenger_root,
+  $passenger_ruby          = $passenger::params::passenger_ruby,
+  $passenger_version       = $passenger::params::passenger_version,
+  $install_config          = $passenger::params::install_config,
+  $passenger_conf_template = $passenger::params::passenger_conf_template,
+  $passenger_load_template = $passenger::params::passenger_load_template,
 ) inherits passenger::params {
 
   include '::apache'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,7 @@ class passenger::params {
       $passenger_load_template = undef
       
       # not sure what fedora operatingsystemmajrelease is so only pulling RHEL 7.x /Centos 7.x
-      if $::operatingsystemmajrelease >= 7 and $::operatingsystemmajrelease < 8 {
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 and versioncmp($::operatingsystemmajrelease, '8') < 0 {
         # need newer version of passenger than 3.0.21
         $package_ensure         = '4.0.57'
         $passenger_version      = '4.0.57'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,12 +11,13 @@
 # Sample Usage:
 #
 class passenger::params {
-  $package_ensure     = '3.0.21'
-  $passenger_version  = '3.0.21'
+  $default_package_ensure     = '3.0.21'
+  $default_passenger_version  = '3.0.21'
   $passenger_ruby     = '/usr/bin/ruby'
   $package_provider   = 'gem'
   $passenger_provider = 'gem'
-
+  
+  
   if versioncmp ($passenger_version, '4.0.0') > 0 {
     $builddir     = 'buildout'
   } else {
@@ -25,6 +26,10 @@ class passenger::params {
 
   case $::osfamily {
     'debian': {
+      $install_config         = true
+      $package_ensure         = $default_package_ensure
+      $passenger_version      = $default_passenger_version
+
       $package_name           = 'passenger'
       $passenger_package      = 'passenger'
       $gem_path               = '/var/lib/gems/1.8/gems'
@@ -38,17 +43,42 @@ class passenger::params {
       } else {
         $package_dependencies   = [ 'libruby', 'libcurl4-openssl-dev' ]
       }
+      $passenger_conf_template = 'passenger/passenger-enabled.erb'
+      $passenger_load_template = 'passenger/passenger-load.erb'
     }
     'redhat': {
-      $package_dependencies   = [ 'libcurl-devel', 'openssl-devel', 'zlib-devel' ]
-      $package_name           = 'passenger'
-      $passenger_package      = 'passenger'
-      $gem_path               = '/usr/lib/ruby/gems/1.8/gems'
-      $gem_binary_path        = '/usr/lib/ruby/gems/1.8/gems/bin'
-      $passenger_root         = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}"
-      $mod_passenger_location = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}/ext/apache2/mod_passenger.so"
+      $install_config          = true
+      $package_name            = 'passenger'
+      $passenger_package       = 'passenger'
+      $package_dependencies    = [ 'libcurl-devel', 'openssl-devel', 'zlib-devel' ]
+      $passenger_conf_template = 'passenger/passenger-conf.erb'
+      $passenger_load_template = undef
+      
+      # not sure what fedora operatingsystemmajrelease is so only pulling RHEL 7.x /Centos 7.x
+      if $::operatingsystemmajrelease >= 7 and $::operatingsystemmajrelease < 8 {
+        # need newer version of passenger than 3.0.21
+        $package_ensure         = '4.0.57'
+        $passenger_version      = '4.0.57'
+        $gem_path               = '/usr/local/share/gems'
+        $gem_binary_path        = '/usr/bin'
+        $passenger_root         = "/usr/local/share/gems/gems/passenger-${passenger_version}"
+        $mod_passenger_location = "/usr/local/share/gems/gems/passenger-${passenger_version}/${builddir}/apache2/mod_passenger.so"
+      } else {
+        $package_ensure         = $default_package_ensure
+        $passenger_version      = $default_passenger_version      
+        $gem_path               = '/usr/lib/ruby/gems/1.8/gems'
+        $gem_binary_path        = '/usr/lib/ruby/gems/1.8/gems/bin'
+        $passenger_root         = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}"
+        $mod_passenger_location = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}/${builddir}/apache2/mod_passenger.so"
+      }
     }
     'darwin':{
+      # config module doesn't currently have branch for darwin so don't install config
+      $install_config         = false
+      $passenger_conf_template = 'passenger/passenger-conf.erb'
+      $passenger_load_template = undef
+      $package_ensure         = $default_package_ensure
+      $passenger_version      = $default_passenger_version
       $package_name           = 'passenger'
       $passenger_package      = 'passenger'
       $gem_path               = '/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -65,7 +65,7 @@ class passenger::params {
         $mod_passenger_location = "/usr/local/share/gems/gems/passenger-${passenger_version}/${builddir}/apache2/mod_passenger.so"
       } else {
         $package_ensure         = $default_package_ensure
-        $passenger_version      = $default_passenger_version      
+        $passenger_version      = $default_passenger_version
         $gem_path               = '/usr/lib/ruby/gems/1.8/gems'
         $gem_binary_path        = '/usr/lib/ruby/gems/1.8/gems/bin'
         $passenger_root         = "/usr/lib/ruby/gems/1.8/gems/passenger-${passenger_version}"


### PR DESCRIPTION
Redhat 7 changes locations of gems and needs a newer version of passenger to compile. There is no passenger module available at this point so I was using this puppet module to compile passenger myself. 
I also wanted the ability to turn off this modules config class because another module I was using was using the apache passenger module which also wants to manage the passenger.conf. 

I tried to keep all the defaults as-is in params.pp