### PR TITLE
Fixing dependency on croddy/make module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
     {"name":"puppetlabs/apache","version_requirement":">= 1.0.0 < 2.0.0"},
     {"name":"puppetlabs/ruby","version_requirement":">= 0.1.0 < 1.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
-    {"name":"croddy/make","version_requirement":">= 0.5.0 < 1.0.0"},
+    {"name":"croddy/make","version_requirement":">= 0.0.5 < 1.0.0"},
     {"name":"puppetlabs/gcc","version_requirement":">= 0.2.0 < 1.0.0"}
   ]
 }


### PR DESCRIPTION
- Switching dependency from 0.5.0 to 0.0.5 as is the latest
  version of the croddy/make module available.

Issue:https://tickets.puppetlabs.com/browse/MODULES-1725