### PR TITLE
Do not condemn dependencies to unstable versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -50,9 +50,9 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/apache","version_requirement":">= 1.0.0 < 2.0.0"},
-    {"name":"puppetlabs/ruby","version_requirement":">= 0.1.0 < 1.0.0"},
+    {"name":"puppetlabs/ruby","version_requirement":">= 0.1.0 < 2.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
-    {"name":"croddy/make","version_requirement":">= 0.0.5 < 1.0.0"},
-    {"name":"puppetlabs/gcc","version_requirement":">= 0.2.0 < 1.0.0"}
+    {"name":"croddy/make","version_requirement":">= 0.0.5 < 2.0.0"},
+    {"name":"puppetlabs/gcc","version_requirement":">= 0.2.0 < 2.0.0"}
   ]
 }


### PR DESCRIPTION
Currently some dependencies are set to not be higher than 1.0.0 which would mean that we always want them to be unstable. Ideally all dependencies would at minimum be 1.0.0 and so the cap at 2.0.0 would make sense. In our case where we are using unstable code and want to enforce an upper limit on the version, that limit should be 2.0.0 so that stable versions are accepted.