### PR TITLE
Use ensure_packages() from stdlib instead of just package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,9 +7,7 @@ class passenger::install {
   }
 
   if $passenger::package_dependencies {
-    package { $passenger::package_dependencies:
-      ensure => present,
-    }
+    ensure_packages ($passenger::package_dependencies)
   }
 
 }


### PR DESCRIPTION
This will play nice with other modules that, e.g., deploy openssl elsewhere.