### PR TITLE
Changed apache module to fix ordering issues

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,10 @@ class passenger::config {
       }
 
       file { '/etc/apache2/mods-enabled/passenger.load':
+        ensure => 'absent',
+      }
+
+      file { '/etc/apache2/mods-enabled/zzz_passenger.load':
         ensure  => 'link',
         target  => '/etc/apache2/mods-available/passenger.load',
         owner   => '0',
@@ -32,6 +36,10 @@ class passenger::config {
       }
 
       file { '/etc/apache2/mods-enabled/passenger.conf':
+        ensure => 'absent',
+      }
+
+      file { '/etc/apache2/mods-enabled/zzz_passenger.conf':
         ensure  => 'link',
         target  => '/etc/apache2/mods-available/passenger.conf',
         owner   => '0',
@@ -44,6 +52,10 @@ class passenger::config {
     'redhat': {
 
       file { '/etc/httpd/conf.d/passenger.conf':
+        ensure => 'absent',
+      }
+
+      file { '/etc/httpd/conf.d/zzz_passenger.conf':
         ensure  => present,
         content => template('passenger/passenger-conf.erb'),
         owner   => '0',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -90,12 +90,12 @@ describe 'passenger' do
     end
 
     it 'adds symlinks mods-enabled to load modules' do
-      should contain_file('/etc/apache2/mods-enabled/passenger.conf').with(
+      should contain_file('/etc/apache2/mods-enabled/zzz_passenger.conf').with(
         :ensure => 'link',
         :target => '/etc/apache2/mods-available/passenger.conf'
       )
 
-      should contain_file('/etc/apache2/mods-enabled/passenger.load').with(
+      should contain_file('/etc/apache2/mods-enabled/zzz_passenger.load').with(
         :ensure => 'link',
         :target => '/etc/apache2/mods-available/passenger.load'
       )


### PR DESCRIPTION
Have changed apache module location from passenger.load to
xxx_passenger.load as most modules need to be before passenger in the
load order, e.g. upload_progress.