### PR TITLE
change type to type3x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class passenger (
     Class['passenger::config']
   }
 
-  if type($include_build_tools) == 'string' {
+  if type3x($include_build_tools) == 'string' {
     $include_build_tools_real = str2bool($include_build_tools)
   } else {
     $include_build_tools_real = $include_build_tools


### PR DESCRIPTION
(Scope(Class[Passenger])) type() DEPRECATED: This function will cease to function on Puppet 4; please use type3x() before upgrading to puppet 4 for backwards-compatibility, or migrate to the new parser's typing system.