### PR TITLE
add Puppet v4.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,41 @@ language: ruby
 bundler_args: --without development
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--color --format documentation'"
 sudo: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.2
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" PARSER="future"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
+
 matrix:
   fast_finish: true
-  include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.5.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.6.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.5.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.6.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
-  allow_failures:
-  - rvm: 2.1.2
-    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  exclude:
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.1.2
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.2
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
 notifications:
   email: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class passenger (
     Class['passenger::config']
   }
 
-  if type($include_build_tools) == 'string' {
+  if type3x($include_build_tools) == 'string' {
     $include_build_tools_real = str2bool($include_build_tools)
   } else {
     $include_build_tools_real = $include_build_tools

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
   "dependencies": [
     {"name":"puppetlabs/apache","version_requirement":">= 1.0.0 < 2.0.0"},
     {"name":"puppetlabs/ruby","version_requirement":">= 0.1.0 < 2.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"croddy/make","version_requirement":">= 0.0.5 < 2.0.0"},
     {"name":"puppetlabs/gcc","version_requirement":">= 0.2.0 < 2.0.0"}
   ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -72,7 +72,7 @@ describe 'passenger' do
         }
       end
 
-      it should_not { contain_class('passenger::compile') }
+      it { should_not contain_class('passenger::compile')}
     end
 
     describe 'with include_build_tools' do

--- a/templates/passenger-load.erb
+++ b/templates/passenger-load.erb
@@ -1,1 +1,1 @@
-LoadModule passenger_module <%= @mod_passenger_location %>
+LoadModule passenger_module <%= scope.lookupvar('passenger::mod_passenger_location') %>


### PR DESCRIPTION
- deprecate type() in favor of type3x() (uses stdlib 4.6.0 therefore)
- add rspec tests for Puppet 3.8.x to 4.2.x
- fix rspec message "PENDING: Not yet implemented"
- align passenger-load.erb for Puppet v4 compatibility
- remove allow_failures section from Travis configuration

