### PR TITLE
Migration from croddy/make to puppet/make

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
     gcc:
       repo: 'git://github.com/puppetlabs/puppetlabs-gcc.git'
     make:
-      repo: 'git://github.com/cmroddy/puppet-make.git'
+      repo: 'git://github.com/voxpupuli/puppet-make.git'
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
     {"name":"puppetlabs/apache","version_requirement":">= 1.0.0 < 2.0.0"},
     {"name":"puppetlabs/ruby","version_requirement":">= 0.1.0 < 2.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"croddy/make","version_requirement":">= 0.0.5 < 2.0.0"},
+    {"name":"puppet/make","version_requirement":">= 0.0.5 < 2.0.0"},
     {"name":"puppetlabs/gcc","version_requirement":">= 0.2.0 < 2.0.0"}
   ]
 }


### PR DESCRIPTION
croddy/make has been moved to puppet/make and maintained by Vox Pupuli.